### PR TITLE
fix: rename schnorr alogrithm id

### DIFF
--- a/ckb-auth-rs/src/lib.rs
+++ b/ckb-auth-rs/src/lib.rs
@@ -14,7 +14,7 @@ pub enum AuthAlgorithmIdType {
     Bitcoin = 4,
     Dogecoin = 5,
     CkbMultisig = 6,
-    SchnorrOrTaproot = 7,
+    Schnorr = 7,
     Rsa = 8,
     Iso97962 = 9,
     Litecoin = 10,

--- a/tests/auth-c-tests/src/lib.rs
+++ b/tests/auth-c-tests/src/lib.rs
@@ -781,7 +781,7 @@ pub fn auth_builder(t: AuthAlgorithmIdType, official: bool) -> result::Result<Bo
             return Ok(DogecoinAuth::new());
         }
         AuthAlgorithmIdType::CkbMultisig => {}
-        AuthAlgorithmIdType::SchnorrOrTaproot => {
+        AuthAlgorithmIdType::Schnorr => {
             return Ok(SchnorrAuth::new());
         }
         AuthAlgorithmIdType::Rsa => {
@@ -1980,7 +1980,7 @@ impl Auth for SchnorrAuth {
         Vec::from(&ckb_hash::blake2b_256(xonly)[..20])
     }
     fn get_algorithm_type(&self) -> u8 {
-        AuthAlgorithmIdType::SchnorrOrTaproot as u8
+        AuthAlgorithmIdType::Schnorr as u8
     }
     fn get_sign_size(&self) -> usize {
         32 + 64

--- a/tests/auth-c-tests/src/tests/mod.rs
+++ b/tests/auth-c-tests/src/tests/mod.rs
@@ -668,7 +668,7 @@ fn ckbmultisig_verify_sing_size_failed() {}
 
 #[test]
 fn schnorr_verify() {
-    unit_test_common(AuthAlgorithmIdType::SchnorrOrTaproot);
+    unit_test_common(AuthAlgorithmIdType::Schnorr);
 }
 
 #[test]


### PR DESCRIPTION
Taproot is not supported, we should rename the alogrithm id to `Schnorr` in rust enum and align with c:

https://github.com/nervosnetwork/ckb-auth/blob/f3cf8752cbb67bd4018fc418d0ff6aaa10bf0599/c/ckb_auth.h#L94