### PR TITLE
feat: add ckb2023 feature flag

### DIFF
--- a/ckb-auth-rs/Cargo.toml
+++ b/ckb-auth-rs/Cargo.toml
@@ -5,7 +5,13 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+ckb2023 = ["ckb-std/ckb2023"]
+
+[dependencies]
+ckb-std = "0.14.3"
+
 [target.'cfg(target_arch = "riscv64")'.dependencies]
-ckb-std = { version = "0.14.3", features = ["ckb2023"] }
 log = { version = "0.4.17", default-features = false}
 hex = { version = "0.4.3", default-features = false, features = ["alloc"]}

--- a/ckb-auth-rs/src/ckb_auth.rs
+++ b/ckb-auth-rs/src/ckb_auth.rs
@@ -9,9 +9,10 @@ use alloc::vec::Vec;
 use ckb_std::{
     ckb_types::core::ScriptHashType,
     dynamic_loading_c_impl::{CKBDLContext, Library, Symbol},
-    high_level::spawn_cell,
     syscalls::SysError,
 };
+#[cfg(feature = "ckb2023")]
+use ckb_std::high_level::spawn_cell;
 use core::mem::size_of_val;
 use hex::encode;
 use log::info;
@@ -66,10 +67,12 @@ pub fn ckb_auth(
     match entry.entry_category {
         // EntryCategoryType::Exec => ckb_auth_exec(entry, id, signature, message),
         EntryCategoryType::DynamicLinking => ckb_auth_dl(entry, id, signature, message),
+        #[cfg(feature = "ckb2023")]
         EntryCategoryType::Spawn => ckb_auth_spawn(entry, id, signature, message),
     }
 }
 
+#[cfg(feature = "ckb2023")]
 fn ckb_auth_spawn(
     entry: &CkbEntryType,
     id: &CkbAuthType,

--- a/ckb-auth-rs/src/lib.rs
+++ b/ckb-auth-rs/src/lib.rs
@@ -55,6 +55,7 @@ impl TryFrom<u8> for AuthAlgorithmIdType {
 pub enum EntryCategoryType {
     // Exec = 0,
     DynamicLinking = 1,
+    #[cfg(feature = "ckb2023")]
     Spawn = 2,
 }
 
@@ -64,6 +65,7 @@ impl TryFrom<u8> for EntryCategoryType {
         match value {
             // 0 => Ok(Self::Exec),
             1 => Ok(Self::DynamicLinking),
+            #[cfg(feature = "ckb2023")]
             2 => Ok(Self::Spawn),
             _ => Err(CkbAuthTypesError::EncodeArgs),
         }

--- a/examples/auth-rust-demo/contracts/auth-rust-demo/Cargo.toml
+++ b/examples/auth-rust-demo/contracts/auth-rust-demo/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 ckb-std = "0.14.3"
-ckb-auth-rs = { path = "../../../../ckb-auth-rs" }
+ckb-auth-rs = { path = "../../../../ckb-auth-rs", features = ["ckb2023"] }
 log = { version = "0.4.17", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"]}
 blake2b-rs = "0.2.0"

--- a/examples/auth-rust-demo/tests/Cargo.toml
+++ b/examples/auth-rust-demo/tests/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 ckb-testtool = "0.10"
-ckb-auth-rs = { path = "../../../ckb-auth-rs" }
+ckb-auth-rs = { path = "../../../ckb-auth-rs", features = ["ckb2023"] }
 
 rand = "0.6.5"

--- a/tests/auth-c-tests/Cargo.toml
+++ b/tests/auth-c-tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-auth-rs = { path = "../../ckb-auth-rs" }
+ckb-auth-rs = { path = "../../ckb-auth-rs", features = ["ckb2023"] }
 ckb-crypto = "0.111.0"
 ckb-error = "0.111.0"
 ckb-hash = "0.111.0"

--- a/tests/auth-spawn-tests/Cargo.toml
+++ b/tests/auth-spawn-tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-auth-rs = { path = "../../ckb-auth-rs" }
+ckb-auth-rs = { path = "../../ckb-auth-rs", features = ["ckb2023"] }
 ckb-debugger-api = { git = "https://github.com/nervosnetwork/ckb-standalone-debugger.git", rev="5077c6c" }
 ckb-mock-tx-types =  { git = "https://github.com/nervosnetwork/ckb-standalone-debugger.git", rev="5077c6c" }
 molecule = { version = "0.7.3", default-features = false }

--- a/tools/ckb-auth-cli/Cargo.toml
+++ b/tools/ckb-auth-cli/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-auth-rs = { path = "../../ckb-auth-rs" }
+ckb-auth-rs = { path = "../../ckb-auth-rs", features = ["ckb2023"] }
 ckb-vm = { version = "0.24.0", features = [ "asm" ] }
 ckb-types = "=0.111.0-rc2"
 ckb-hash = "=0.111.0-rc2"


### PR DESCRIPTION
ckb2023 hardfork is not activated on mainnet or testnet yet, we should use a feature flag to enable it and by default off.