### PR TITLE
Remove monero testcase

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -78,9 +78,10 @@ clean-spawn-tests:
 install-all: \
 	install-ckb-tools \
 	install-litecoin-tools \
-	install-monero-tools \
 	install-solana-tools \
 	install-cardano-tools
+
+# 	install-monero-tools
 
 install-ckb-tools: \
 	bin \
@@ -144,12 +145,12 @@ install-litecoin-tools:
 	rm -rf litecoin*
 	bin/litecoin-cli --version
 
-install-monero-tools:
-	wget -nv $(monero_tools_url)
-	tar xvf `basename -- $(monero_tools_url)`
-	cp -r monero-*/* bin
-	rm -rf monero-* bin/ANONYMITY_NETWORKS.md bin/README.md bin/LICENSE
-	bin/monero-wallet-cli --version
+# install-monero-tools:
+# 	wget -nv $(monero_tools_url)
+# 	tar xvf `basename -- $(monero_tools_url)`
+# 	cp -r monero-*/* bin
+# 	rm -rf monero-* bin/ANONYMITY_NETWORKS.md bin/README.md bin/LICENSE
+# 	bin/monero-wallet-cli --version
 
 install-solana-tools:
 	wget -nv $(solana_tools_url)

--- a/tests/auth-c-tests/src/tests/mod.rs
+++ b/tests/auth-c-tests/src/tests/mod.rs
@@ -315,7 +315,7 @@ fn litecoin_verify_official() {
     unit_test_common_official(AuthAlgorithmIdType::Litecoin);
 }
 
-#[test]
+// #[test]
 fn monero_verify() {
     unit_test_common(AuthAlgorithmIdType::Monero);
 }


### PR DESCRIPTION
* Remove monero. Because the signature of the monero official website has expired, the precompiled file cannot be obtained for testing.