### PR TITLE
fix: Ripple tx_blob parsing can overflow stack buffer

### DIFF
--- a/c/auth.c
+++ b/c/auth.c
@@ -425,7 +425,8 @@ int validate_signature_ripple(uint8_t *prefilled_data, uint8_t algorithm_id,
 
     RippleSignatureData sign_data;
     sign_data.sign_msg = out_sign_msg_buf;
-
+    sign_data.sign_msg_capacity = sizeof(out_sign_msg_buf);
+    
     CHECK2(!get_ripple_verify_data(sig, sig_len, &sign_data),
            ERROR_INVALID_ARG);
     CHECK2(memcmp(sign_data.ckb_msg, msg, RIPPLE_ACCOUNT_ID_SIZE) == 0,

--- a/c/ripple.h
+++ b/c/ripple.h
@@ -42,6 +42,7 @@ typedef struct {
     size_t sign_data_len;
     uint8_t *sign_msg;
     size_t sign_msg_len;
+    size_t sign_msg_capacity;
 } RippleSignatureData;
 
 enum RIPPLE_ERROR {
@@ -148,23 +149,30 @@ int get_ripple_verify_data(const uint8_t *sign, size_t sign_len,
                         break;
                     case 4:
                         out->sign_data_len = buf_len;
+                        CHECK2(buf_len <= sizeof(out->sign_data),
+                               RIPPLE_ERROR_PARSE_SIGN_LEN_INVADE);
                         CHECK2(sign_len >= buf_len,
                                RIPPLE_ERROR_PARSE_OUT_OF_BOUND);
                         memcpy(out->sign_data, sign, buf_len);
 
                         // generate sign message
+                        size_t sign_data_pos = sign - sign_base_ptr - 2;
+                        size_t sign_msg_len = sizeof(G_RIPPLE_SIGN_HEAD) +
+                                              sign_data_pos +
+                                              (sign_len - buf_len);
+                        CHECK2(sign_msg_len <= out->sign_msg_capacity,
+                               RIPPLE_ERROR_PARSE_OUT_OF_BOUND);
+
                         uint8_t *sign_msg_ptr = out->sign_msg;
                         memcpy(sign_msg_ptr, G_RIPPLE_SIGN_HEAD,
                                sizeof(G_RIPPLE_SIGN_HEAD));
-                        sign_msg_ptr += 4;
-                        out->sign_msg_len = 4;
+                        sign_msg_ptr += sizeof(G_RIPPLE_SIGN_HEAD);
+                        out->sign_msg_len = sizeof(G_RIPPLE_SIGN_HEAD);
 
-                        size_t sign_data_pos = sign - sign_base_ptr - 2;
                         memcpy(sign_msg_ptr, sign_base_ptr, sign_data_pos);
                         sign_msg_ptr += sign_data_pos;
                         out->sign_msg_len += sign_data_pos;
                         SIGN_BUFF_OFFSET(buf_len);
-                        CHECK2(sign_len >= 0, RIPPLE_ERROR_PARSE_OUT_OF_BOUND);
                         memcpy(sign_msg_ptr, sign, sign_len);
                         out->sign_msg_len += sign_len;
                         break;


### PR DESCRIPTION
by adding sign_msg_capacity and update validation logic in get_ripple_verify_data to ensure proper handling of sign message size.